### PR TITLE
v0.6.1

### DIFF
--- a/examples-generic-kubernetes/github-actions/gws/01_chart_gws-services/override_values.yaml
+++ b/examples-generic-kubernetes/github-actions/gws/01_chart_gws-services/override_values.yaml
@@ -39,6 +39,8 @@ gwsServices:
     context:
       env:
         GWS_PROVISIONING_COMMON_LOGLEVEL: info
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
         GWS_SERVICE_CONF_URL: http://gws-service-proxy.gws:80
         GWS_SERVICE_VOICEMAIL_URL: http://voice-voicemail-service.voice.svc:8081/fs
         # Enables/disables SSL connection to PostgreSQL. Possible values: disable, prefer, require, verify-ca, verify-full
@@ -71,6 +73,8 @@ gwsServices:
         GWS_SECURE_COOKIE: true
         GWS_SERVICE_VOICEMAIL_URL: http://voice-voicemail-service.voice.svc:8081/fs
         GWS_WORKSPACE_CONSUL_AUTH_ENV_DISABLED: true
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformChat:
     enabled: true    
@@ -85,7 +89,7 @@ gwsServices:
       requests:
         cpu: 0.2
         memory: 700Mi
-        
+
   gwsPlatformConfiguration:
     deployment:
       replicaCount: 1
@@ -104,9 +108,10 @@ gwsServices:
         GWS_CONFIGURATION_timeouts_environmentRefreshMs: 300000
         GWS_CONFIGURATION_cache_tenantRefreshIntervalMin: 1
         GWS_CS_CLUSTER_SUPPORT: true
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
-
-  gwsPlatformDatacollector:  
+  gwsPlatformDatacollector:
     deployment:
       replicaCount: 1
 
@@ -121,6 +126,8 @@ gwsServices:
     context:
       env:
         GWS_DATACOLLECTOR_timeouts_environmentRefreshMs: 300000
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformIxn:
     deployment:
@@ -137,6 +144,8 @@ gwsServices:
     context:
       env:
         GWS_IXN_timeouts_environmentRefreshMs: 60000
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80        
 
   gwsPlatformOcs:
     deployment:
@@ -153,7 +162,9 @@ gwsServices:
     context:
       env:
         GWS_OCS_timeouts_environmentRefreshMs: 300000
-  
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
+
   gwsPlatformSetting:
     deployment:
       replicaCount: 1
@@ -169,7 +180,8 @@ gwsServices:
     context:
       env:
         GWS_SETTING_timeouts_environmentRefreshMs: 300000
-        #GWS_SETTING_db_readOnly: true
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformStatistics:
     deployment:
@@ -186,6 +198,8 @@ gwsServices:
     context:
       env:
         GWS_STATISTICS_timeouts_environmentRefreshMs: 300000
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformUcs:
     enabled: true   
@@ -208,6 +222,8 @@ gwsServices:
         GWS_VOICE_timeouts_environmentRefreshMs: 10000
         GWS_AUTH_COMMON_ENV_SERVICE: http://gauth-environment.gauth:80
         #GWS_PSDK_ENHANCED_PROTOCOL_SECURITY: true
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsUiCrmworkspace:
     deployment:
@@ -216,7 +232,6 @@ gwsServices:
   gwsUiProvisioning:
     deployment:
       replicaCount: 1
-
 
 ### 3rd Party services
 consul:

--- a/examples-gke/github-actions/gws/01_chart_gws-services/override_values.yaml
+++ b/examples-gke/github-actions/gws/01_chart_gws-services/override_values.yaml
@@ -39,6 +39,8 @@ gwsServices:
     context:
       env:
         GWS_PROVISIONING_COMMON_LOGLEVEL: info
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
         GWS_SERVICE_CONF_URL: http://gws-service-proxy.gws:80
         GWS_SERVICE_VOICEMAIL_URL: http://voice-voicemail-service.voice.svc:8081/fs
         # Enables/disables SSL connection to PostgreSQL. Possible values: disable, prefer, require, verify-ca, verify-full
@@ -71,6 +73,8 @@ gwsServices:
         GWS_SECURE_COOKIE: true
         GWS_SERVICE_VOICEMAIL_URL: http://voice-voicemail-service.voice.svc:8081/fs
         GWS_WORKSPACE_CONSUL_AUTH_ENV_DISABLED: true
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformChat:
     enabled: true    
@@ -104,6 +108,8 @@ gwsServices:
         GWS_CONFIGURATION_timeouts_environmentRefreshMs: 300000
         GWS_CONFIGURATION_cache_tenantRefreshIntervalMin: 1
         GWS_CS_CLUSTER_SUPPORT: true
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformDatacollector:
     deployment:
@@ -120,6 +126,8 @@ gwsServices:
     context:
       env:
         GWS_DATACOLLECTOR_timeouts_environmentRefreshMs: 300000
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformIxn:
     deployment:
@@ -136,6 +144,8 @@ gwsServices:
     context:
       env:
         GWS_IXN_timeouts_environmentRefreshMs: 60000
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80        
 
   gwsPlatformOcs:
     deployment:
@@ -152,6 +162,8 @@ gwsServices:
     context:
       env:
         GWS_OCS_timeouts_environmentRefreshMs: 300000
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformSetting:
     deployment:
@@ -168,6 +180,8 @@ gwsServices:
     context:
       env:
         GWS_SETTING_timeouts_environmentRefreshMs: 300000
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformStatistics:
     deployment:
@@ -184,6 +198,8 @@ gwsServices:
     context:
       env:
         GWS_STATISTICS_timeouts_environmentRefreshMs: 300000
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformUcs:
     enabled: true   
@@ -206,6 +222,8 @@ gwsServices:
         GWS_VOICE_timeouts_environmentRefreshMs: 10000
         GWS_AUTH_COMMON_ENV_SERVICE: http://gauth-environment.gauth:80
         #GWS_PSDK_ENHANCED_PROTOCOL_SECURITY: true
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsUiCrmworkspace:
     deployment:

--- a/examples-openshift/github-actions/gws/01_chart_gws-services/override_values.yaml
+++ b/examples-openshift/github-actions/gws/01_chart_gws-services/override_values.yaml
@@ -30,6 +30,7 @@ dnsConfig:
 
 gwsServices:
   gwsAppProvisioning:
+
     deployment:
       replicaCount: 1
 
@@ -44,6 +45,8 @@ gwsServices:
     context:
       env:
         GWS_PROVISIONING_COMMON_LOGLEVEL: info
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
         GWS_SERVICE_CONF_URL: http://gws-service-proxy.gws:80
         GWS_SERVICE_VOICEMAIL_URL: http://voice-voicemail-service.voice.svc:8081/fs
         # Enables/disables SSL connection to PostgreSQL. Possible values: disable, prefer, require, verify-ca, verify-full
@@ -60,6 +63,7 @@ gwsServices:
   gwsAppWorkspace:
     deployment:
       replicaCount: 1
+
     resources:
       limits:
         cpu: 0.8
@@ -75,9 +79,12 @@ gwsServices:
         GWS_SECURE_COOKIE: true
         GWS_SERVICE_VOICEMAIL_URL: http://voice-voicemail-service.voice.svc:8081/fs
         GWS_WORKSPACE_CONSUL_AUTH_ENV_DISABLED: true
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformChat:
     enabled: true    
+
     deployment:
       replicaCount: 1
 
@@ -107,6 +114,8 @@ gwsServices:
         GWS_CONFIGURATION_timeouts_environmentRefreshMs: 300000
         GWS_CONFIGURATION_cache_tenantRefreshIntervalMin: 1
         GWS_CS_CLUSTER_SUPPORT: true
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformDatacollector:
     deployment:
@@ -123,6 +132,8 @@ gwsServices:
     context:
       env:
         GWS_DATACOLLECTOR_timeouts_environmentRefreshMs: 300000
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformIxn:
     deployment:
@@ -139,6 +150,8 @@ gwsServices:
     context:
       env:
         GWS_IXN_timeouts_environmentRefreshMs: 60000
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80        
 
   gwsPlatformOcs:
     deployment:
@@ -155,6 +168,8 @@ gwsServices:
     context:
       env:
         GWS_OCS_timeouts_environmentRefreshMs: 300000
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformSetting:
     deployment:
@@ -171,7 +186,8 @@ gwsServices:
     context:
       env:
         GWS_SETTING_timeouts_environmentRefreshMs: 300000
-        #GWS_SETTING_db_readOnly: true
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformStatistics:
     deployment:
@@ -188,6 +204,8 @@ gwsServices:
     context:
       env:
         GWS_STATISTICS_timeouts_environmentRefreshMs: 300000
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsPlatformUcs:
     enabled: true   
@@ -209,6 +227,9 @@ gwsServices:
         GWS_VOICE_timeouts_requestTimeoutMs: 30000
         GWS_VOICE_timeouts_environmentRefreshMs: 10000
         GWS_AUTH_COMMON_ENV_SERVICE: http://gauth-environment.gauth:80
+        #GWS_PSDK_ENHANCED_PROTOCOL_SECURITY: true
+        GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
+        GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80
 
   gwsUiCrmworkspace:
     deployment:
@@ -217,7 +238,6 @@ gwsServices:
   gwsUiProvisioning:
     deployment:
       replicaCount: 1
-
 
 ### 3rd Party services
 consul:


### PR DESCRIPTION
Keep auth and env urls in gws service overrides.
GWS_SERVICE_AUTH_URL: http://gauth-auth.gauth:80
GWS_SERVICE_ENV_URL: http://gauth-environment.gauth:80